### PR TITLE
Format design document as markdown

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,48 +1,40 @@
-Proxy Auth Design (AKS user-scoped tokens from a pod)
-1) Goal (what this proxy does)
+# Proxy Auth Design (AKS user-scoped tokens from a pod)
+
+## 1. Goal (what this proxy does)
 
 Expose a small HTTP service that:
 
-Signs users in with Microsoft Entra (Auth Code + PKCE).
+- Signs users in with Microsoft Entra (Authorization Code flow + PKCE).
+- Mints a user-scoped access token for AKS (`aud=6dae42f8-4368-4678-94ff-3960e28e3630`) using MSAL.
+- Runs in-cluster (inside the same AKS) and can execute cluster actions (for example, run `kubectl` or call the Kubernetes API) as the signed-in user (RBAC enforced by AKS).
+- Works with Workload Identity: the pod proves app identity via `client_assertion` from the federated token file (no client secrets).
+- Supports multiple concurrent users or sessions and multi-browser logins.
+- (Optional) Provides per-user rate limits and basic audit logs.
 
-Mints a user-scoped access token for AKS (aud=6dae42f8-4368-4678-94ff-3960e28e3630) using MSAL.
+Non-goals (initially): full multi-cluster brokering, long-lived refresh token sync across replicas (we can add Redis later), group overage mitigation via Microsoft Graph calls, or SSO frontends.
 
-Runs in-cluster (inside the same AKS) and can execute cluster actions (e.g., run kubectl or call the Kubernetes API) as the signed-in user (RBAC enforced by AKS).
+## 2. High-level architecture
 
-Works with Workload Identity: the pod proves app identity via client_assertion from the federated token file (no client secrets).
+### Actors
 
-Supports multiple concurrent users/sessions and multi-browser logins.
+- Browser user → hits the proxy's `/login`; completes Entra sign-in.
+- Proxy (this service) → FastAPI/Flask app inside AKS; uses MSAL to redeem codes, store the token cache, and fetch AKS tokens.
+- Microsoft Entra ID (STS) → issues ID and refresh tokens (for the app) and AKS user-scoped access tokens.
+- AKS API server → validates bearer tokens, then authorizes using AKS RBAC or Azure RBAC for Kubernetes.
 
-(Optional) Per-user rate-limits and basic audit logs.
+### Trust material
 
-Non-goals (initially): full multi-cluster brokering, long-lived refresh token sync across replicas (we can add Redis later), group overage mitigation via Graph calls, or SSO frontends.
+- Client assertion: read from `AZURE_FEDERATED_TOKEN_FILE` (Workload Identity) to authenticate the app (confidential client) to Entra.
+- Cluster CA: for TLS to the in-cluster API server (usually `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`).
 
-2) High-level architecture
+## 3. Auth flows (clean, predictable)
 
-Actors
+### 3.1. User sign-in (OIDC only)
 
-Browser user → hits the proxy’s /login; completes Entra sign-in.
+1. `/login`: redirect to Entra with scopes `["openid", "profile", "offline_access"]` (no resource scopes).
+2. `/callback`: redeem the auth code, receive the ID token (user identity) and refresh token, then persist `MSAL SerializableTokenCache` to the server session (or Redis) and store `home_account_id` in the session.
 
-Proxy (this service) → FastAPI/Flask app inside AKS; uses MSAL to redeem codes, store token cache, and fetch AKS tokens.
+### 3.2. Acquire user-scoped AKS token
 
-Microsoft Entra ID (STS) → issues ID/refresh tokens (for app) and AKS user-scoped access tokens.
+Rebuild the MSAL client with the same cache and call the AKS token acquisition flow.
 
-AKS API server → validates bearer tokens, then authorizes using AKS RBAC or Azure RBAC for Kubernetes.
-
-Trust material
-
-Client assertion: read from AZURE_FEDERATED_TOKEN_FILE (Workload Identity) to authenticate the app (confidential client) to Entra.
-
-Cluster CA: for TLS to the in-cluster API server (usually /var/run/secrets/kubernetes.io/serviceaccount/ca.crt).
-
-3) Auth flows (clean, predictable)
-3.1 User sign-in (OIDC only)
-
-/login: redirect to Entra with scopes ["openid","profile","offline_access"] (no resource scopes).
-
-/callback: redeem auth code → receive ID token (user identity) + refresh token.
-Persist MSAL SerializableTokenCache to the server session (or Redis), and store home_account_id in session.
-
-3.2 Acquire user-scoped AKS token
-
-Rebuild MSAL client with the same cache and call:


### PR DESCRIPTION
## Summary
- convert `design.md` to structured Markdown with headings, bullet lists, and code formatting for key terms

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cfa286e504832594deb914bdf235af