### PR TITLE
Add Dockerfile and Helm chart for AKS deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.env
+venv/
+.git
+.gitignore
+chart/
+README.md
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install system dependencies and CA certificates for outbound HTTPS requests.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies separately to leverage Docker layer caching.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+# Copy application source.
+COPY app ./app
+
+# Create a non-root user to run the service.
+RUN useradd --create-home --uid 1000 appuser
+USER appuser
+
+EXPOSE 8080
+
+# Launch the FastAPI application with uvicorn.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/chart/oauth-proxy/.helmignore
+++ b/chart/oauth-proxy/.helmignore
@@ -1,0 +1,7 @@
+# Patterns to ignore when packaging Helm charts.
+*.swp
+*.bak
+*.tmp
+.DS_Store
+.git/
+.gitignore

--- a/chart/oauth-proxy/Chart.yaml
+++ b/chart/oauth-proxy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: oauth-proxy
+description: A Helm chart for deploying the AKS OAuth proxy service.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/chart/oauth-proxy/templates/NOTES.txt
+++ b/chart/oauth-proxy/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Thank you for installing {{ include "oauth-proxy.fullname" . }}.
+
+This deployment exposes the proxy on port {{ .Values.service.port }}. You can access it by running:
+
+  kubectl port-forward svc/{{ include "oauth-proxy.fullname" . }} 8080:{{ .Values.service.port }}
+
+Remember to configure the required settings (tenantId, clientId, redirectUri, and sessionSecret) before deploying.

--- a/chart/oauth-proxy/templates/_helpers.tpl
+++ b/chart/oauth-proxy/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{- define "oauth-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "oauth-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "oauth-proxy.labels" -}}
+helm.sh/chart: {{ include "oauth-proxy.chart" . }}
+{{ include "oauth-proxy.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "oauth-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oauth-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "oauth-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{ include "oauth-proxy.fullname" . }}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth-proxy.sessionSecretName" -}}
+{{- if .Values.sessionSecret.existingSecret -}}
+{{- .Values.sessionSecret.existingSecret -}}
+{{- else -}}
+{{- printf "%s-session" (include "oauth-proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/oauth-proxy/templates/deployment.yaml
+++ b/chart/oauth-proxy/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oauth-proxy.fullname" . }}
+  labels:
+    {{- include "oauth-proxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "oauth-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oauth-proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "oauth-proxy.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: TENANT_ID
+              value: {{ required "settings.tenantId is required" .Values.settings.tenantId | quote }}
+            - name: CLIENT_ID
+              value: {{ required "settings.clientId is required" .Values.settings.clientId | quote }}
+            - name: REDIRECT_URI
+              value: {{ required "settings.redirectUri is required" .Values.settings.redirectUri | quote }}
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "oauth-proxy.sessionSecretName" . }}
+                  key: {{ .Values.sessionSecret.key | default "session-secret" }}
+            - name: AZURE_FEDERATED_TOKEN_FILE
+              value: {{ .Values.settings.federatedTokenFile | quote }}
+            - name: SESSION_COOKIE_NAME
+              value: {{ .Values.settings.sessionCookieName | quote }}
+            - name: SESSION_COOKIE_SECURE
+              value: {{ printf "%t" .Values.settings.sessionCookieSecure | quote }}
+            - name: SESSION_COOKIE_SAMESITE
+              value: {{ .Values.settings.sessionCookieSameSite | quote }}
+            - name: SESSION_IDLE_TIMEOUT_SECONDS
+              value: {{ printf "%d" .Values.settings.sessionIdleTimeoutSeconds | quote }}
+            - name: SESSION_ABSOLUTE_TIMEOUT_SECONDS
+              value: {{ printf "%d" .Values.settings.sessionAbsoluteTimeoutSeconds | quote }}
+          {{- with .Values.settings.extraEnv }}
+          {{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/oauth-proxy/templates/ingress.yaml
+++ b/chart/oauth-proxy/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "oauth-proxy.fullname" . }}
+  labels:
+    {{- include "oauth-proxy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "oauth-proxy.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/oauth-proxy/templates/secret.yaml
+++ b/chart/oauth-proxy/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.sessionSecret.existingSecret }}
+{{- $secretValue := required "sessionSecret.value must be provided when sessionSecret.existingSecret is empty" .Values.sessionSecret.value }}
+{{- $secretKey := .Values.sessionSecret.key | default "session-secret" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oauth-proxy.sessionSecretName" . }}
+  labels:
+    {{- include "oauth-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ $secretKey }}: {{ $secretValue | quote }}
+{{- end }}

--- a/chart/oauth-proxy/templates/service.yaml
+++ b/chart/oauth-proxy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oauth-proxy.fullname" . }}
+  labels:
+    {{- include "oauth-proxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "oauth-proxy.selectorLabels" . | nindent 4 }}

--- a/chart/oauth-proxy/templates/serviceaccount.yaml
+++ b/chart/oauth-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oauth-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "oauth-proxy.labels" . | nindent 4 }}
+    {{- if .Values.serviceAccount.azureWorkloadIdentity.enabled }}
+    azure.workload.identity/use: "true"
+    {{- end }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $wiEnabled := .Values.serviceAccount.azureWorkloadIdentity.enabled }}
+  {{- if or $wiEnabled .Values.serviceAccount.annotations }}
+  annotations:
+    {{- if $wiEnabled }}
+    azure.workload.identity/client-id: {{ required "serviceAccount.azureWorkloadIdentity.clientId is required when workload identity is enabled" .Values.serviceAccount.azureWorkloadIdentity.clientId | quote }}
+    {{- with .Values.serviceAccount.azureWorkloadIdentity.tenantId }}
+    azure.workload.identity/tenant-id: {{ . | quote }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/oauth-proxy/values.yaml
+++ b/chart/oauth-proxy/values.yaml
@@ -1,0 +1,99 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/your-org/oauth-proxy
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  labels: {}
+  azureWorkloadIdentity:
+    enabled: true
+    clientId: ""  # Application (client) ID for the workload identity
+    tenantId: ""  # Microsoft Entra tenant ID for workload identity tokens
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+settings:
+  tenantId: ""  # Microsoft Entra tenant ID used for user sign-in
+  clientId: ""  # Application (client) ID used by the proxy
+  redirectUri: ""  # Redirect URI configured in the app registration
+  federatedTokenFile: /var/run/secrets/azure/tokens/azure-identity-token
+  sessionCookieName: proxy_session
+  sessionCookieSecure: true
+  sessionCookieSameSite: lax
+  sessionIdleTimeoutSeconds: 1800
+  sessionAbsoluteTimeoutSeconds: 28800
+  extraEnv: []
+
+sessionSecret:
+  existingSecret: ""  # Set to use a pre-created secret instead of creating one
+  key: session-secret  # Key within the secret that stores SESSION_SECRET
+  value: ""  # Plaintext session secret when not using an existing secret
+
+livenessProbe:
+  enabled: true
+  path: /
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+containerPort: 8080


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs the FastAPI proxy dependencies and runs uvicorn as a non-root user
- introduce a Helm chart for deploying the proxy to AKS with workload identity annotations and required configuration knobs
- provide chart defaults and helper templates for configuring environment variables, probes, and service exposure

## Testing
- python -m compileall app

