### PR TITLE
Fix incremental consent scope

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 
 
+AKS_RESOURCE_APP_ID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+DEFAULT_AKS_SCOPE = f"{AKS_RESOURCE_APP_ID}/.default"
+DEFAULT_AKS_DELEGATED_SCOPE = f"{AKS_RESOURCE_APP_ID}/user_impersonation"
+
+
 @dataclass
 class Settings:
     """Runtime settings loaded from the environment."""
@@ -24,7 +29,8 @@ class Settings:
     oidc_scopes: list[str] = field(
         default_factory=lambda: ["openid", "profile", "offline_access"]
     )
-    aks_scope: str = "6dae42f8-4368-4678-94ff-3960e28e3630/.default"
+    aks_scope: str = DEFAULT_AKS_SCOPE
+    aks_delegated_scope: str = DEFAULT_AKS_DELEGATED_SCOPE
 
     @property
     def authority(self) -> str:
@@ -94,5 +100,9 @@ def get_settings() -> Settings:
         session_cookie_name=os.getenv("SESSION_COOKIE_NAME", "proxy_session"),
         cookie_secure=cookie_secure,
         cookie_samesite=cookie_samesite,
+        aks_scope=os.getenv("AKS_SCOPE", DEFAULT_AKS_SCOPE),
+        aks_delegated_scope=os.getenv(
+            "AKS_DELEGATED_SCOPE", DEFAULT_AKS_DELEGATED_SCOPE
+        ),
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -108,9 +108,10 @@ def _start_incremental_consent(
     # code challenge pair and persist the verifier in the session.
     verifier, challenge = create_pkce_pair()
     state = _new_state()
+    incremental_scopes = [settings.aks_delegated_scope]
     session[AUTH_FLOW_KEY] = {
         "state": state,
-        "scopes": [settings.aks_scope],
+        "scopes": incremental_scopes,
         "type": "consent",
         "code_verifier": verifier,
         "created_at": int(time.time()),
@@ -118,7 +119,7 @@ def _start_incremental_consent(
 
     login_hint = account.get("username")
     auth_url = client.get_authorization_request_url(
-        scopes=[settings.aks_scope],
+        scopes=incremental_scopes,
         redirect_uri=settings.redirect_uri,
         state=state,
         prompt="consent",
@@ -134,7 +135,7 @@ def _start_incremental_consent(
         "Starting incremental consent flow",
         {
             "authorization_url": auth_url,
-            "scopes": [settings.aks_scope],
+            "scopes": incremental_scopes,
             "state": state,
             "user": {
                 "home_account_id": account.get("home_account_id"),

--- a/design.md
+++ b/design.md
@@ -76,7 +76,7 @@ Store:
 
 Preferred: pre-grant AKS delegated permission to your client app (App Registration → API permissions → Azure Kubernetes Service AAD Server → Delegated → `user_impersonation` → Grant admin consent). Then `/.default` is silent.
 
-Otherwise: handle incremental consent once—if silent fails, redirect with `scopes=[AKS_APP/.default]` + `prompt=consent`. After callback, future silent works. (This mirrors Microsoft’s guidance on incremental consent & “UI required” paths.)
+Otherwise: handle incremental consent once—if silent fails, redirect with `scopes=[AKS_APP/user_impersonation]` + `prompt=consent`. After callback, future silent works. (This mirrors Microsoft’s guidance on incremental consent & “UI required” paths.)
 
 ## 7. Workload Identity (confidential client with `client_assertion`)
 
@@ -116,7 +116,7 @@ Per-user sliding window (e.g., 60 requests/min). Key on `home_account_id`. Store
 
 ## 12. Failure modes & handling
 
-- `MsalUiRequiredException` / silent returns `None` → trigger incremental consent flow for `AKS_APP/.default` (one-time).
+- `MsalUiRequiredException` / silent returns `None` → trigger incremental consent flow for `AKS_APP/user_impersonation` (one-time).
 - `401/403` from API server → check `aud=AKS`, user vs. app token (`idtyp` must not be "app"), RBAC bindings.
 - “cert signed by unknown authority” → supply cluster CA or use kubeconfig with CA embedded.
 - Empty `get_accounts()` → you’re not restoring the same MSAL cache; fix cache persistence.


### PR DESCRIPTION
## Summary
- add explicit defaults for the AKS resource and delegated scopes in the configuration
- request the delegated `user_impersonation` scope during incremental consent instead of the `.default` alias
- document that incremental consent uses the delegated scope in the design notes

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d194e0839883259e121bf3d74094e4