### PR TITLE
Update kubelogin sample to workload identity flow

### DIFF
--- a/examples/kubelogin_flow/README.md
+++ b/examples/kubelogin_flow/README.md
@@ -1,0 +1,81 @@
+# kubelogin-style AKS token acquisition
+
+This example mirrors kubelogin's **workload identity** login mode so you can
+exercise the same flow the proxy uses inside a pod. Instead of prompting a user,
+it exchanges the federated token mounted by Azure Workload Identity for a
+delegated AKS access token.
+
+## Prerequisites
+
+* An Azure Kubernetes Service cluster with [workload identity](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+  enabled.
+* A service account annotated for workload identity with the client ID and
+  tenant ID of the Microsoft Entra application registration you want to use.
+* The pod running this script must have access to the federated token file (for
+  example `/var/run/secrets/azure/tokens/azure-identity-token`).
+* Install the Azure Identity SDK:
+
+  ```bash
+  pip install azure-identity
+  ```
+
+## Running the script
+
+1. Start a pod (or container) with the workload identity environment variables
+   exported. Azure injects these automatically when the service account is
+   configured correctly, but you can export them manually for testing:
+
+   ```bash
+   export AZURE_CLIENT_ID="<workload identity app client id>"
+   export AZURE_TENANT_ID="<tenant guid>"
+   export AZURE_FEDERATED_TOKEN_FILE="/var/run/secrets/azure/tokens/azure-identity-token"
+   ```
+
+2. Optionally override the AKS resource or scope:
+
+   ```bash
+   export AKS_SERVER_APP_ID="6dae42f8-4368-4678-94ff-3960e28e3630"  # default
+   # export AZURE_SCOPE="6dae42f8-4368-4678-94ff-3960e28e3630/User.Read"
+   ```
+
+3. Run the helper:
+
+   ```bash
+   python examples/kubelogin_flow/aks_workload_identity.py
+   ```
+
+The script will exchange the federated token for an access token targeting the
+AKS resource (`<server-app-id>/.default` unless you supplied an explicit scope).
+It prints the expiration time and a truncated view of the resulting access
+token so you can confirm the flow completed successfully.
+
+### Verifying the prerequisites
+
+If the script fails with an authorization error, double-check that:
+
+* The Microsoft Entra application tied to your workload identity has been
+  granted delegated access to the **Azure Kubernetes Service AAD Server**
+  resource (either via the portal or `az ad app permission add`).
+* The service account annotation matches the client ID you exported and the pod
+  is reading the federated token file mounted by Azure Workload Identity.
+* `AKS_SERVER_APP_ID` points at the server application backing your AKS
+  cluster. The default (`6dae42f8-4368-4678-94ff-3960e28e3630`) targets the
+  Microsoft-managed AKS resource.
+
+## Customizing the authority
+
+If you need to target a sovereign cloud, set either:
+
+* `AZURE_CLOUD` to one of `AzurePublicCloud` (default), `AzureUSGovernment`, or
+  `AzureChinaCloud`, or
+* `AZURE_AUTHORITY_HOST` to the exact authority host you want to use
+  (overrides `AZURE_CLOUD`).
+
+## Relationship to kubelogin
+
+kubelogin's `--login workloadidentity` path constructs an
+`azidentity.WorkloadIdentityCredential` using the same inputs this sample
+expects: client ID, tenant ID, federated token file path, and optional cloud
+configuration. By exercising the flow directly you can validate that the
+workload identity assignment and AKS delegated permissions are configured
+correctly before wiring them into the proxy.

--- a/examples/kubelogin_flow/aks_workload_identity.py
+++ b/examples/kubelogin_flow/aks_workload_identity.py
@@ -1,0 +1,108 @@
+"""Exchange a workload identity token for an AKS access token.
+
+This script mirrors kubelogin's workload-identity login by presenting the
+service account token issued by Kubernetes to Azure AD and exchanging it for
+an AKS user token targeting the managed cluster resource.
+
+Run it from a pod (or any environment) configured for Azure Workload Identity.
+
+Usage:
+    export AZURE_CLIENT_ID=<federated workload app client id>
+    export AZURE_TENANT_ID=<tenant guid>
+    export AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token
+    python examples/kubelogin_flow/aks_workload_identity.py
+
+Optional environment variables:
+    AKS_SERVER_APP_ID   Server application (resource) ID. Defaults to the
+                        Microsoft AKS server app (6dae42f8-4368-4678-94ff-3960e28e3630).
+    AZURE_SCOPE         Explicit scope string. Overrides AKS_SERVER_APP_ID when
+                        provided.
+    AZURE_AUTHORITY_HOST Azure cloud authority host. Defaults to the value
+                        implied by AZURE_CLOUD or https://login.microsoftonline.com.
+    AZURE_CLOUD         Friendly cloud name (AzurePublicCloud, AzureUSGovernment,
+                        AzureChinaCloud). Ignored when AZURE_AUTHORITY_HOST is set.
+
+The script requires the ``azure-identity`` package:
+    pip install azure-identity
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from azure.identity import AzureAuthorityHosts, WorkloadIdentityCredential
+
+
+CLOUD_AUTHORITIES = {
+    "azurepubliccloud": AzureAuthorityHosts.AZURE_PUBLIC_CLOUD,
+    "azureusgovernment": AzureAuthorityHosts.AZURE_GOVERNMENT,
+    "azurechinacloud": AzureAuthorityHosts.AZURE_CHINA,
+}
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        print(f"Environment variable {name} is required.", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _resolve_authority_host() -> str:
+    explicit = os.getenv("AZURE_AUTHORITY_HOST")
+    if explicit:
+        return explicit
+
+    cloud = os.getenv("AZURE_CLOUD", "AzurePublicCloud").lower()
+    authority = CLOUD_AUTHORITIES.get(cloud)
+    if not authority:
+        supported = ", ".join(sorted(CLOUD_AUTHORITIES))
+        raise ValueError(
+            f"Unsupported AZURE_CLOUD '{cloud}'. Supported values: {supported}."
+        )
+    return authority
+
+
+def _resolve_scope(server_app_id: str) -> str:
+    scope_override = os.getenv("AZURE_SCOPE")
+    if scope_override:
+        return scope_override
+    return f"{server_app_id}/.default"
+
+
+def main() -> None:
+    client_id = _require_env("AZURE_CLIENT_ID")
+    tenant_id = _require_env("AZURE_TENANT_ID")
+    token_file = _require_env("AZURE_FEDERATED_TOKEN_FILE")
+    server_app_id = os.getenv(
+        "AKS_SERVER_APP_ID", "6dae42f8-4368-4678-94ff-3960e28e3630"
+    )
+
+    scope = _resolve_scope(server_app_id)
+    authority_host = _resolve_authority_host()
+
+    credential = WorkloadIdentityCredential(
+        client_id=client_id,
+        tenant_id=tenant_id,
+        token_file_path=token_file,
+        authority_host=authority_host,
+    )
+
+    token = credential.get_token(scope)
+
+    print("Successfully obtained AKS access token via workload identity.")
+    print(f"Token expires on: {token.expires_on}")
+    access_token = token.token
+    print("Access token (truncated):")
+    print(access_token[:40] + "..." + access_token[-10:])
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Aborted by user", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001 - surface clear errors for operators
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- replace the kubelogin example with a workload identity helper that mirrors kubelogin's `--login workloadidentity` mode
- document how to run the script inside a pod using the federated token file and optional scope/authority overrides
- restore the README with troubleshooting notes for verifying delegated permissions and workload identity setup

## Testing
- python -m compileall examples/kubelogin_flow

------
https://chatgpt.com/codex/tasks/task_e_68d40f136bb88325b2d590721784cdc4